### PR TITLE
Apply migration from Alexandria.Migration

### DIFF
--- a/1_Object_Oriented/Alexandria.WebApi.sln
+++ b/1_Object_Oriented/Alexandria.WebApi.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Alexandria.Local.Integratio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Alexandria.SQLSeeding", "src\Commons\Alexandria.SQLSeeding\Alexandria.SQLSeeding.csproj", "{77DE46C0-A177-4DD8-8561-77061118F466}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Alexandria.Migration", "src\Infrastructure\Alexandria.Migration\Alexandria.Migration.csproj", "{A42D92C6-B192-4E52-A469-66273A2A00C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +124,10 @@ Global
 		{77DE46C0-A177-4DD8-8561-77061118F466}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77DE46C0-A177-4DD8-8561-77061118F466}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77DE46C0-A177-4DD8-8561-77061118F466}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A42D92C6-B192-4E52-A469-66273A2A00C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A42D92C6-B192-4E52-A469-66273A2A00C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A42D92C6-B192-4E52-A469-66273A2A00C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A42D92C6-B192-4E52-A469-66273A2A00C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,5 +154,6 @@ Global
 		{E2797F65-0422-4979-8164-D644CF676CC4} = {E9386FA2-8440-47A0-B3AA-D3C67A600298}
 		{181B9946-93AE-431A-9D1B-ABB575799166} = {E2797F65-0422-4979-8164-D644CF676CC4}
 		{77DE46C0-A177-4DD8-8561-77061118F466} = {EC4DC049-6886-471B-B02C-A9FA1EBC5740}
+		{A42D92C6-B192-4E52-A469-66273A2A00C6} = {0DDEEF4A-9FFD-452B-9D45-625847711E64}
 	EndGlobalSection
 EndGlobal

--- a/1_Object_Oriented/aspire/AppHost/AppHost.csproj
+++ b/1_Object_Oriented/aspire/AppHost/AppHost.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Commons\WellKnowns\WellKnowns.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\..\src\Infrastructure\Alexandria.Persistence\Alexandria.Persistence.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\..\src\Infrastructure\Alexandria.Migration\Alexandria.Migration.csproj" />
     <ProjectReference Include="..\..\src\Presentation\Alexandria.WebApi\Alexandria.WebApi.csproj" />
   </ItemGroup>
 

--- a/1_Object_Oriented/aspire/AppHost/Configurations/TestConfiguration.cs
+++ b/1_Object_Oriented/aspire/AppHost/Configurations/TestConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using Alexandria.Persistence;
-using WellKnowns.Infrastructure.SQL;
+﻿using WellKnowns.Infrastructure.SQL;
 using WellKnowns.Presentation.AlexandriaWebApi;
 
 namespace AppHost.Configurations;
@@ -12,45 +11,63 @@ internal static class TestConfiguration
     {
         // Sql
         var (sqlServer, sqldb) = ConfigureSqlDb(builder);
-        OnDBCreateApplySqlDbMigrations(builder);
+
+        var migration = builder.ConfigureMigration(sqlServer, sqldb);
 
         // WebApi
-        builder.ConfigureWebApi(sqlServer, sqldb);
+        builder.ConfigureWebApi(sqlServer, sqldb, migration);
 
         return builder;
     }
 
-    private static IDistributedApplicationBuilder ConfigureWebApi(
+    private static IResourceBuilder<ProjectResource> ConfigureMigration(
         this IDistributedApplicationBuilder builder,
         IResourceBuilder<SqlServerServerResource> sqlServer,
         IResourceBuilder<SqlServerDatabaseResource> sqldb
     )
     {
-#pragma warning disable CA2012 // Use ValueTasks correctly
-        string SqlConnectionString()
-        {
-            var awaiter = sqlServer.Resource.GetConnectionStringAsync().GetAwaiter();
-            while (!awaiter.IsCompleted)
-            {
-                Thread.Sleep(10);
-            }
-
-            var connectionString = awaiter.GetResult();
-            return connectionString is null
-                ? throw new InvalidOperationException("Could not retrieve SQL ConnectionString")
-                : EnforceDatabaseName(connectionString)
-                    ?? throw new InvalidOperationException("ConnectionString not found");
-#pragma warning restore CA2012 // Use ValueTasks correctly
-        }
-
-        builder
-            .AddProject<Projects.Alexandria_WebApi>(WebApiProjectReferences.ProjectName)
-            .WithEndpoint()
-            .WithEnvironment(SqldbEnvVars.SQLConnectionString, SqlConnectionString)
+        var migration = builder
+            .AddProject<Projects.Alexandria_Migration>("migration")
+            .WithEnvironment(SqldbEnvVars.SQLConnectionString, () => SqlConnectionString(sqlServer))
             .WithReference(sqldb)
             .WaitFor(sqldb);
 
+        return migration;
+    }
+
+    private static IDistributedApplicationBuilder ConfigureWebApi(
+        this IDistributedApplicationBuilder builder,
+        IResourceBuilder<SqlServerServerResource> sqlServer,
+        IResourceBuilder<SqlServerDatabaseResource> sqldb,
+        IResourceBuilder<ProjectResource> migration
+    )
+    {
+        builder
+            .AddProject<Projects.Alexandria_WebApi>(WebApiProjectReferences.ProjectName)
+            .WithEndpoint()
+            .WithEnvironment(SqldbEnvVars.SQLConnectionString, () => SqlConnectionString(sqlServer))
+            .WithReference(sqldb)
+            .WaitFor(sqldb)
+            .WaitForCompletion(migration);
+
         return builder;
+    }
+
+#pragma warning disable CA2012 // Use ValueTasks correctly
+    private static string SqlConnectionString(IResourceBuilder<SqlServerServerResource> sqlServer)
+    {
+        var awaiter = sqlServer.Resource.GetConnectionStringAsync().GetAwaiter();
+        while (!awaiter.IsCompleted)
+        {
+            Thread.Sleep(10);
+        }
+
+        var connectionString = awaiter.GetResult();
+        return connectionString is null
+            ? throw new InvalidOperationException("Could not retrieve SQL ConnectionString")
+            : EnforceDatabaseName(connectionString)
+                ?? throw new InvalidOperationException("ConnectionString not found");
+#pragma warning restore CA2012 // Use ValueTasks correctly
     }
 
     private static (
@@ -89,26 +106,5 @@ internal static class TestConfiguration
         return sqlConnectionString.Contains(databaseSegment, StringComparison.OrdinalIgnoreCase)
             ? sqlConnectionString
             : $"{sqlConnectionString};{databaseSegment}";
-    }
-
-    private static void OnDBCreateApplySqlDbMigrations(IDistributedApplicationBuilder builder)
-    {
-        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>(
-            static async (@event, cancellationToken) =>
-            {
-                var db =
-                    @event.Model.Resources.First(x => x.Name == SqlProjectReferences.ProjectName)
-                    as SqlServerServerResource;
-
-                ArgumentNullException.ThrowIfNull(db, nameof(db));
-
-                var connectionString = await db.GetConnectionStringAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                ArgumentNullException.ThrowIfNull(connectionString, nameof(connectionString));
-
-                AlexandriaDbContextFactory.ApplyDbMigrations(connectionString);
-            }
-        );
     }
 }

--- a/1_Object_Oriented/src/Infrastructure/Alexandria.Migration/Alexandria.Migration.csproj
+++ b/1_Object_Oriented/src/Infrastructure/Alexandria.Migration/Alexandria.Migration.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Alexandria.Persistence\Alexandria.Persistence.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/1_Object_Oriented/src/Infrastructure/Alexandria.Migration/Program.cs
+++ b/1_Object_Oriented/src/Infrastructure/Alexandria.Migration/Program.cs
@@ -1,0 +1,13 @@
+﻿using Alexandria.Persistence;
+using WellKnowns.Infrastructure.SQL;
+
+var sqlConnectionString =
+    args.ElementAtOrDefault(0)
+    ?? Environment.GetEnvironmentVariable(SqldbEnvVars.SQLConnectionString);
+
+ArgumentException.ThrowIfNullOrWhiteSpace(
+    sqlConnectionString,
+    nameof(SqldbEnvVars.SQLConnectionString)
+);
+
+AlexandriaDbContextFactory.ApplyDbMigrations(sqlConnectionString);

--- a/1_Object_Oriented/src/Infrastructure/Alexandria.Persistence/Alexandria.Persistence.csproj
+++ b/1_Object_Oriented/src/Infrastructure/Alexandria.Persistence/Alexandria.Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -32,7 +32,7 @@
 
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>AppHost</_Parameter1>
+            <_Parameter1>Alexandria.Migration</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
 </Project>

--- a/1_Object_Oriented/test/IntegrationTests/Alexandria.Local.IntegrationTests/GlobalUsing.cs
+++ b/1_Object_Oriented/test/IntegrationTests/Alexandria.Local.IntegrationTests/GlobalUsing.cs
@@ -1,4 +1,4 @@
-﻿global using Aspire.Hosting.ApplicationModel;
+﻿global using static Alexandria.Local.IntegrationTests.Support.KiotaExtensions;
+global using Aspire.Hosting.ApplicationModel;
 global using Aspire.Hosting.Testing;
 global using Microsoft.Extensions.DependencyInjection;
-global using static Alexandria.Local.IntegrationTests.Support.KiotaExtensions;


### PR DESCRIPTION
- AfterResourcesCreatedEvent is not blocking therefore a race condition could happen if the migrations took longer than the application to start.
- Following the recommendations [here](https://github.com/dotnet/docs-aspire/blob/main/docs/fundamentals/app-host-overview.md#waiting-for-resources), I have moved the migration to an application. The WebApi now wait for completion of this migration app before to continue.